### PR TITLE
Modify an equality check in the code that checks on reflect.Value instances

### DIFF
--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -641,7 +641,7 @@ func (d *decoder) mapping(n *node, out reflect.Value) (good bool) {
 }
 
 func (d *decoder) setMapIndex(n *node, out, k, v reflect.Value) {
-	if d.strict && out.MapIndex(k) != zeroValue {
+	if d.strict && out.MapIndex(k).Interface() != zeroValue.Interface() {
 		d.terrors = append(d.terrors, fmt.Sprintf("line %d: key %#v already set in map", n.line+1, k.Interface()))
 		return
 	}


### PR DESCRIPTION
In file: decoder.go, a logical equality check operation is performed between two `reflect.Value` instances that represent run-time data. This is incorrect because it compares the `reflect` package's internal representations, which is typically not intended. Instead, the intent is most likely to compare the underlying values. I suggested that such comparison should be done with `value.Interface()`. 

This should be reviewed and if the business logic actually demands that the equality should be done in the currently prescribed way, the pull request may be ignored. I could not determine what is the most appropriate equality check for this context.

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.


